### PR TITLE
ncm-metaconfig: no name field for rsyslog input statement

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/rsyslog/input.tt
+++ b/ncm-metaconfig/src/main/metaconfig/rsyslog/input.tt
@@ -1,6 +1,5 @@
 input(
 [% FILTER indent -%]
-name="[% name %]"
 type="im[% type %]"
 [%-     options = {};
         options.import(params);

--- a/ncm-metaconfig/src/main/metaconfig/rsyslog/inputs.tt
+++ b/ncm-metaconfig/src/main/metaconfig/rsyslog/inputs.tt
@@ -1,4 +1,4 @@
 [%- FOREACH input IN CCM.contents.input.pairs %]
 [% # One input-type per named input
-      INCLUDE 'metaconfig/rsyslog/input.tt' name=input.key type=input.value.keys.0 params=input.value.values.0 -%]
+      INCLUDE 'metaconfig/rsyslog/input.tt' type=input.value.keys.0 params=input.value.values.0 -%]
 [% END -%]


### PR DESCRIPTION
The input statement (at least for imfile) does not come with a name field. So if needed, it should be provided in the configuration and not be added by default.
